### PR TITLE
Use bool instead of boolean in examples

### DIFF
--- a/examples/DallasTemperatureSensor/DallasTemperatureSensor.ino
+++ b/examples/DallasTemperatureSensor/DallasTemperatureSensor.ino
@@ -46,8 +46,8 @@ OneWire oneWire(ONE_WIRE_BUS); // Setup a oneWire instance to communicate with a
 DallasTemperature sensors(&oneWire); // Pass the oneWire reference to Dallas Temperature. 
 float lastTemperature[MAX_ATTACHED_DS18B20];
 int numSensors=0;
-boolean receivedConfig = false;
-boolean metric = true; 
+bool receivedConfig = false;
+bool metric = true;
 // Initialize temperature message
 MyMessage msg(0,V_TEMP);
 

--- a/examples/DhtTemperatureAndHumiditySensor/DhtTemperatureAndHumiditySensor.ino
+++ b/examples/DhtTemperatureAndHumiditySensor/DhtTemperatureAndHumiditySensor.ino
@@ -66,7 +66,7 @@ float lastTemp;
 float lastHum;
 uint8_t nNoUpdatesTemp;
 uint8_t nNoUpdatesHum;
-boolean metric = true; 
+bool metric = true;
 
 MyMessage msgHum(CHILD_ID_HUM, V_HUM);
 MyMessage msgTemp(CHILD_ID_TEMP, V_TEMP);

--- a/examples/DistanceSensor/DistanceSensor.ino
+++ b/examples/DistanceSensor/DistanceSensor.ino
@@ -46,7 +46,7 @@ unsigned long SLEEP_TIME = 5000; // Sleep time between reads (in milliseconds)
 NewPing sonar(TRIGGER_PIN, ECHO_PIN, MAX_DISTANCE); // NewPing setup of pins and maximum distance.
 MyMessage msg(CHILD_ID, V_DISTANCE);
 int lastDist;
-boolean metric = true; 
+bool metric = true;
 
 void setup()  
 { 

--- a/examples/IrrigationController/IrrigationController.ino
+++ b/examples/IrrigationController/IrrigationController.ino
@@ -145,10 +145,10 @@ int lastValve;
 unsigned long startMillis;
 const int ledPin = 5;
 const int waterButtonPin = 3;
-boolean buttonPushed = false;
-boolean showTime = true;
-boolean clockUpdating = false;
-boolean recentUpdate = true;
+bool buttonPushed = false;
+bool showTime = true;
+bool clockUpdating = false;
+bool recentUpdate = true;
 const char *dayOfWeek[] = {
   "Null", "Sunday ", "Monday ", "Tuesday ", "Wednesday ", "Thursday ", "Friday ", "Saturday "
 };
@@ -246,7 +246,7 @@ void setup()
     lcd.setCursor(0, 1);
     lcd.print(F(" Valve Data: "));
     lcd.print(i);
-    boolean flashIcon = false;
+    bool flashIcon = false;
     DEBUG_PRINT(F("Calling for Valve "));
     DEBUG_PRINT(i);
     DEBUG_PRINTLN(F(" Data..."));
@@ -542,7 +542,7 @@ void slowToggleLED ()
 //
 void receive(const MyMessage &message)
 {
-  boolean zoneTimeUpdate = false;
+  bool zoneTimeUpdate = false;
   if (message.isAck())
   {
     DEBUG_PRINTLN(F("This is an ack from gateway"));
@@ -656,7 +656,7 @@ void receive(const MyMessage &message)
 void updateDisplay()
 {
   static unsigned long lastUpdateTime;
-  static boolean displayToggle = false;
+  static bool displayToggle = false;
   //static byte toggleCounter = 0;
   static SprinklerStates lastDisplayState;
   if (state != lastDisplayState || millis() - lastUpdateTime >= 3000UL)

--- a/examples/MAX6875TemperatureSensor/MAX6875TemperatureSensor.ino
+++ b/examples/MAX6875TemperatureSensor/MAX6875TemperatureSensor.ino
@@ -53,7 +53,7 @@ uint8_t units = 1; // Units to readout temp (0 = ˚F, 1 = ˚C)
 float temperature = 0.0; // Temperature output variable
 float lastTemperature;
 unsigned long SLEEP_TIME = 30000;
-boolean metric = true;
+bool metric = true;
 
 MyMessage msg(0, V_TEMP);
 

--- a/examples/PressureSensor/PressureSensor.ino
+++ b/examples/PressureSensor/PressureSensor.ino
@@ -79,7 +79,7 @@ float pressureAvg;
 float pressureAvg2;
 
 float dP_dt;
-boolean metric;
+bool metric;
 MyMessage tempMsg(TEMP_CHILD, V_TEMP);
 MyMessage pressureMsg(BARO_CHILD, V_PRESSURE);
 MyMessage forecastMsg(BARO_CHILD, V_FORECAST);

--- a/examples/RFIDLockSensor/RFIDLockSensor.ino
+++ b/examples/RFIDLockSensor/RFIDLockSensor.ino
@@ -107,7 +107,7 @@ void presentation()  {
 }
  
 void loop() {
-  boolean success;
+  bool success;
   uint8_t key[] = { 0, 0, 0, 0, 0, 0, 0 };  // Buffer to store the returned UID
   uint8_t currentKeyLength;                        // Length of the UID (4 or 7 bytes depending on ISO14443A card type)
 
@@ -132,7 +132,7 @@ void loop() {
 
     Serial.println("");
 
-    boolean valid = false;
+    bool valid = false;
     // Compare this key to the valid once registered here in sketch 
     for (int i=0;i<keyCount && !valid;i++) {
       for (int j=0;j<currentKeyLength && !valid;j++) {

--- a/examples/RainGauge/RainGauge.ino
+++ b/examples/RainGauge/RainGauge.ino
@@ -101,7 +101,7 @@ MyMessage msgTrippedVar2(CHILD_ID_TRIPPED_INDICATOR, V_VAR2);
   DHT dht;
   float lastTemp;
   float lastHum;
-  boolean metric = true;
+  bool metric = true;
   MyMessage msgHum(CHILD_ID_HUM, V_HUM);
   MyMessage msgTemp(CHILD_ID_TEMP, V_TEMP);
 #endif
@@ -133,7 +133,7 @@ byte state = 0;
 byte oldState = -1;
 unsigned int lastRainRate = 0;
 int lastMeasure = 0;
-boolean gotTime = false;
+bool gotTime = false;
 byte lastHour;
 byte currentHour;
 //
@@ -162,7 +162,7 @@ void setup()
   //
   //retrieve from EEPROM stored values on a power cycle.
   //
-  boolean isDataOnEeprom = false;
+  bool isDataOnEeprom = false;
   for (int i = 0; i < E_BUFFER_LENGTH; i++)
   {
     byte locator = loadState(EEPROM_BUFFER_LOCATION + i);
@@ -590,7 +590,7 @@ void prettyFade(void)
 
 void slowFlash(void)
 {
-  static boolean ledState = true;
+  static bool ledState = true;
   static unsigned long pulseStart = millis();
   if (millis() - pulseStart < 100UL)
   {

--- a/examples/RealTimeClockDisplaySensor/RealTimeClockDisplaySensor.ino
+++ b/examples/RealTimeClockDisplaySensor/RealTimeClockDisplaySensor.ino
@@ -53,7 +53,7 @@
 #include <Wire.h>
 #include <LiquidCrystal_I2C.h>
 
-boolean timeReceived = false;
+bool timeReceived = false;
 unsigned long lastUpdate=0, lastRequest=0;
 
 // Initialize display. Google the correct settings for your display. 

--- a/examples/SMSGatewayNode/SMSGatewayNode.ino
+++ b/examples/SMSGatewayNode/SMSGatewayNode.ino
@@ -122,8 +122,8 @@
 
 // variables
 
-boolean KnowMyOwner = false;
-boolean MsgReceived = false;
+bool KnowMyOwner = false;
+bool MsgReceived = false;
 uint16_t smslen = 0;
 int8_t smsnum = 0;
 int bufferindex = 0;

--- a/examples/TimeAwareSensor/TimeAwareSensor.ino
+++ b/examples/TimeAwareSensor/TimeAwareSensor.ino
@@ -36,7 +36,7 @@
 #include <MySensors.h>  
 #include <Time.h>  
 
-boolean timeReceived = false;
+bool timeReceived = false;
 unsigned long lastUpdate=0, lastRequest=0;
 
 void setup()  

--- a/examples/TouchDisplaySceneControllerSensor/TouchDisplaySceneControllerSensor.ino
+++ b/examples/TouchDisplaySceneControllerSensor/TouchDisplaySceneControllerSensor.ino
@@ -100,7 +100,7 @@ MyMessage off(CHILD_ID, V_SCENE_OFF);
 UTFT myGLCD(ITDB32S,38,39,40,41);
 UTouch  myTouch( 6, 5, 4, 3, 2);
 UTFT_Buttons  myButtons(&myGLCD, &myTouch);
-boolean timeReceived = false;
+bool timeReceived = false;
 unsigned long lastTimeUpdate=0, lastRequest=0;
 char timeBuf[20];
 

--- a/examples/WeatherStationSensor/WeatherStationSensor.ino
+++ b/examples/WeatherStationSensor/WeatherStationSensor.ino
@@ -75,7 +75,7 @@ const float SEALEVEL_PRESSURE = 1013.25;
 DHT dht;
 float lastTemp;
 float lastHum;
-boolean metric = true;
+bool metric = true;
 MyMessage msgHum(CHILD_ID_HUM, V_HUM);
 MyMessage msgTemp(CHILD_ID_TEMP2, V_TEMP);
 


### PR DESCRIPTION
In the Arduino IDE, boolean is an alias for bool.
The Arduino IDE might deprecate boolean in the future, see
https://github.com/arduino/Arduino/issues/4673 for details.

A similar issue has been created for the mail git repo,
https://github.com/mysensors/MySensors/pull/544