### PR TITLE
receivedInitialValue in setup look not reset

### DIFF
--- a/examples/IrrigationController/IrrigationController.ino
+++ b/examples/IrrigationController/IrrigationController.ino
@@ -253,6 +253,7 @@ void setup()
     DEBUG_PRINT(F("Calling for Valve "));
     DEBUG_PRINT(i);
     DEBUG_PRINTLN(F(" Data..."));
+    receivedInitialValue = false;
     while (!receivedInitialValue)
     {
       lcd.setCursor(15, 0);


### PR DESCRIPTION
Irrigation Controller Project
This update corrects a problem in that initial read of valve times misses V_VAR1 as the receivedInitialValue is not reset to false during the loop when going into the V_VAR1 receive loop.