### PR TITLE
Update IrrigationController.ino

### DIFF
--- a/examples/IrrigationController/IrrigationController.ino
+++ b/examples/IrrigationController/IrrigationController.ino
@@ -252,6 +252,7 @@ void setup()
     goGetValveTimes();
   }
   lcd.clear();
+  inSetup = false;
 }
 
 


### PR DESCRIPTION
After setup, every time goGetValveTimes() is called, the code below always gets run screwing up the information on the screen because inSetup is never changed from true to false in the setup() code.

    if (inSetup) {
      lcd.print(F(" Updating  "));
      lcd.setCursor(0, 1);
      lcd.print(F(" Valve Data: "));
      lcd.print(valveIndex);
    }

Simply added "inSetup = false;" at the end of the setup() code after goGetValveTimes() is run for the first time.