### PR TITLE
Fix farenheit conversion

### DIFF
--- a/libraries/SI7021/SI7021.cpp
+++ b/libraries/SI7021/SI7021.cpp
@@ -38,7 +38,7 @@ bool SI7021::sensorExists() {
 }
 
 int SI7021::getFahrenheitHundredths() {
-    unsigned int c = getCelsiusHundredths();
+    int c = getCelsiusHundredths();
     return (1.8 * c) + 3200;
 }
 


### PR DESCRIPTION
When temperature in C was below 0, the conversion to F was wrong due to
treating the C value as unsigned integer instead of signed integer.

See http://bit.ly/3ckRfxp for more information.

Thanks to hoggin for reporting this problem.