### PR TITLE
Update RelayWithButtonActuator.ino to replace S_LIGHT

### DIFF
--- a/examples/RelayWithButtonActuator/RelayWithButtonActuator.ino
+++ b/examples/RelayWithButtonActuator/RelayWithButtonActuator.ino
@@ -80,7 +80,7 @@ void presentation()  {
   sendSketchInfo("Relay & Button", "1.0");
 
   // Register all sensors to gw (they will be created as child devices)
-  present(CHILD_ID, S_LIGHT);
+  present(CHILD_ID, S_BINARY);
 }
 
 /*


### PR DESCRIPTION
The value S_LIGHT was deprecated in 2.0 and later removed.